### PR TITLE
override the default devise registrations controller to automatically…

### DIFF
--- a/app/controllers/api/registrations_controller.rb
+++ b/app/controllers/api/registrations_controller.rb
@@ -1,0 +1,13 @@
+class API::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  def create
+    super do |resource|
+      resource.build_account(account_params) if resource.save
+    end
+  end
+
+  private
+
+  def account_params
+    params.permit(:name)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 require 'devise_token_auth'
 
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
+    mount_devise_token_auth_for 'User', at: 'auth', controllers: {
+      registrations:  'api/registrations'
+    }
     resources :stores do
       resources :categories do
         resources :items


### PR DESCRIPTION
… build an associated account and reroutes the auth routes under the umbrella of the api namespace